### PR TITLE
[QPD-375] Updated version

### DIFF
--- a/authlib/consts.py
+++ b/authlib/consts.py
@@ -1,5 +1,5 @@
 name = 'authlib'
-version = 'plt.3952.1'
+version = '1.0.dev374'
 author = 'Quartic.ai Engineering Team'
 homepage = 'https://github.com/Quarticai/authlib'
 


### PR DESCRIPTION
We needed to change the `_version` format, which the latest PIP no longer supports.